### PR TITLE
Add files to blacklist

### DIFF
--- a/patch-npm-packages.js
+++ b/patch-npm-packages.js
@@ -33,6 +33,9 @@ module.exports = function ($logger, $projectData, $usbLiveSyncService) {
     "tns-core-modules",
     "typescript",
     "form-data",
+    "replace-in-file",
+    "glob",
+    "fs.realpath",
     ".bin"
   ];
 


### PR DESCRIPTION
Looks like these dependencies are used in the prepare hook. 
After the hook has executed once it replaces `fs` with `nativescript-node/fs`. Next time the hook is run at build time it fails with `Cannot find module 'file-system/file-system-access`

Resolves #24