### PR TITLE
To patch the node_modules in platforms folder using after_prepare hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     },
     "hooks": [
       {
-        "type": "before-prepare",
-        "script": "patch-npm-packages.js",
+        "type": "after-prepare",
+        "script": "patch-platforms.js",
         "inject": true
       }
     ],

--- a/patch-npm-packages.js
+++ b/patch-npm-packages.js
@@ -224,7 +224,7 @@ module.exports = function ($logger, $projectData, $usbLiveSyncService) {
     }
 
     // patch global dependencies
-    var appPackageJson = require(path.join(__dirname, "..", "..", "package.json"));
+    var appPackageJson = require($projectData.projectFilePath);
     var customGlobalPatches = appPackageJson.nativescript["nodeify"] ? appPackageJson.nativescript["nodeify"]["global-dependencies"] || {} : {};
     for (var p in packages) {
       patchPackage(packages[p], customGlobalPatches);

--- a/patch-platforms.js
+++ b/patch-platforms.js
@@ -1,0 +1,13 @@
+module.exports = function ($logger, $projectData, $usbLiveSyncService, $platformsData, hookArgs) {
+    var path = require("path");
+    var platformName = hookArgs.platform.toLowerCase();
+    
+    //appDestinationDir is the platform specific app folder. For Android, this will be YOUR_PROJECT_ROOT/platforms/android/src/main/assets/
+    var appDestinationDir = $platformsData.getPlatformData(platformName).appDestinationDirectoryPath;
+    var patchNpmPackageDir = path.join(appDestinationDir, "app", "tns_modules", "nativescript-nodeify", "patch-npm-packages.js");
+    
+    //Calling patch-npm-packages.js under platforms to patch the node_modules in the platforms folder.
+    //This will leave the source code folder YOUR_PROJECT_ROOT/node_modules untouched.
+    var patchNpmPackage = require(patchNpmPackageDir);
+    patchNpmPackage($logger, $projectData, $usbLiveSyncService);
+}


### PR DESCRIPTION
I gave it a try to make the plugin patch the node_modules in the platforms folder rather than the source folder. It seems working ok. Here is what I did:

In package.json, change the before_prepare hook to after_prepare hook and points to a new script file called patch_platform.js
In patch_platform.js, require the platform specific patch-npm-packages.js.
In patch-npm-packages.js, on line 227, require the package.json file from the source dir. The code logic is the same as before.