### PR TITLE
Use $logger.trace for logging

### DIFF
--- a/patch-npm-packages.js
+++ b/patch-npm-packages.js
@@ -10,8 +10,7 @@ module.exports = function ($logger, $projectData, $usbLiveSyncService) {
       replaceInFile = require('replace-in-file');
 
   function log(what) {
-    // enable this line to see what the nodeify plugin is up to
-    // console.log(what);
+    $logger.trace(what);
   }
 
   var shims = require('./shims.json');


### PR DESCRIPTION
If someone runs `tns prepare --log trace $ENV`, this will now show all logging info, without anybody needing to edit `patch-npm-packages.js`.