### PR TITLE
Set flag initialized to false in order to work NS>4.1

### DIFF
--- a/patch-npm-packages.js
+++ b/patch-npm-packages.js
@@ -1,7 +1,7 @@
 module.exports = function ($logger, $projectData, $usbLiveSyncService) {
   var liveSync = $usbLiveSyncService.isInitialized;
 
-  if (liveSync) {
+  if (!liveSync) {
     return;
   }
 


### PR DESCRIPTION
Currently hook is not working for NS>4.1 because of `$usbLiveSyncService.isInitialized` is *true* for all cases